### PR TITLE
Fix when using a custom tag

### DIFF
--- a/helm/gitea-mirror/templates/deployment.yaml
+++ b/helm/gitea-mirror/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
       containers:
         - name: gitea-mirror
-          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion | toString }}
+          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Hello,

The correct behavior should be:
* Nothing: we tag the AppVersion and add v in front to match the tagging used by the official Docker images
* A custom tag is provided: we use it directly

Without this modification, custom images need to be prefixed with a "v"